### PR TITLE
Updated bitsandbytes==0.45.0 to bitsandbytes==0.46.0 to fix Warning message.

### DIFF
--- a/requirementsTorch27.txt
+++ b/requirementsTorch27.txt
@@ -8,13 +8,14 @@ annotated-types==0.7.0
 anyio==4.8.0
 ascii-magic==2.3.0
 av==14.0.1
-bitsandbytes==0.45.0
+bitsandbytes==0.46.0
 certifi==2025.1.31
 charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
 contourpy==1.3.1
 cycler==0.12.1
+decord
 diffusers==0.32.1
 easydict==1.13
 einops==0.7.0
@@ -36,6 +37,7 @@ httpcore==1.0.7
 httpx==0.28.1
 huggingface-hub==0.26.5
 idna==3.10
+imageio-ffmpeg
 importlib_metadata==8.6.1
 Jinja2==3.1.3
 kiwisolver==1.4.8
@@ -94,5 +96,3 @@ wcwidth==0.2.13
 websockets==14.2
 Werkzeug==3.1.3
 zipp==3.21.0
-imageio-ffmpeg
-decord


### PR DESCRIPTION
Updated bitsandbytes==0.45.0 to bitsandbytes==0.46.0 to fix warning message.

SUBPROCESS: WARNING:bitsandbytes.cextension:Could not find the bitsandbytes CUDA binary at WindowsPath('K:/H1111/H1111/env/Lib/site-packages/bitsandbytes/libbitsandbytes_cuda128.dll')
SUBPROCESS: WARNING:bitsandbytes.cextension:The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.